### PR TITLE
tweet image upload api

### DIFF
--- a/tweets/api/serializers.py
+++ b/tweets/api/serializers.py
@@ -1,7 +1,10 @@
 from rest_framework import serializers
+from rest_framework.exceptions import ValidationError
+from tweets.services import TweetService
 from likes.services import LikeService
 from likes.api.serializers import LikeSerializer
 from accounts.api.serializers import UserSerializerForTweet
+from tweets.constants import TWEET_PHOTOS_UPLOAD_LIMIT
 from tweets.models import Tweet
 from comments.api.serializers import CommentSerializer
 
@@ -11,6 +14,7 @@ class TweetSerializer(serializers.ModelSerializer):
     comments_count = serializers.SerializerMethodField()
     likes_count = serializers.SerializerMethodField()
     has_liked = serializers.SerializerMethodField()
+    photo_urls = serializers.SerializerMethodField()
 
     class Meta:
         model = Tweet
@@ -22,6 +26,7 @@ class TweetSerializer(serializers.ModelSerializer):
             'comments_count',
             'likes_count',
             'has_liked',
+            'photo_urls',
         )
 
     def get_likes_count(self, obj):
@@ -32,6 +37,12 @@ class TweetSerializer(serializers.ModelSerializer):
 
     def get_has_liked(self, obj):
         return LikeService.has_liked(self.context['request'].user, obj)
+
+    def get_photo_urls(self, obj):
+        photo_urls = []
+        for photo in obj.tweetphoto_set.all().order_by('order'):
+            photo_urls.append(photo.file.url)
+        return photo_urls
 
 
 class TweetSerializerForDetail(TweetSerializer):
@@ -51,18 +62,38 @@ class TweetSerializerForDetail(TweetSerializer):
             'likes_count',
             'comments_count',
             'has_liked',
+            'photo_urls',
         )
 
 
 class TweetSerializerForCreate(serializers.ModelSerializer):
     content = serializers.CharField(min_length=6, max_length=140)
+    files = serializers.ListField(
+        child=serializers.FileField(),
+        allow_empty=True,
+        required=False,
+    )
 
     class Meta:
         model = Tweet
-        fields = ('content',)
+        fields = ('content','files')
+
+    def validate(self, data):
+        if len(data.get('files', [])) > TWEET_PHOTOS_UPLOAD_LIMIT:
+            raise ValidationError({
+                'message': f'You can upload {TWEET_PHOTOS_UPLOAD_LIMIT} photos '
+                           'at most'
+            })
+        return data
 
     def create(self, validated_data):
         user = self.context['request'].user
         content = validated_data['content']
         tweet = Tweet.objects.create(user=user, content=content)
+        if validated_data.get('files'):
+            TweetService.create_photos_from_files(
+                tweet,
+                validated_data['files'],
+            )
+
         return tweet

--- a/tweets/api/tests.py
+++ b/tweets/api/tests.py
@@ -1,6 +1,7 @@
+from django.core.files.uploadedfile import SimpleUploadedFile
 from rest_framework.test import APIClient
 from testing.testcases import TestCase
-from tweets.models import Tweet
+from tweets.models import Tweet, TweetPhoto
 
 
 # make sure to end the testing URL with '/', or it will return error 301
@@ -86,3 +87,66 @@ class TweetApiTests(TestCase):
         self.create_comment(self.user1, tweet, 'hmm...')
         response = self.anonymous_client.get(url)
         self.assertEqual(len(response.data['comments']), 2)
+
+    def test_create_with_files(self):
+        # upload a empty set
+        response = self.user1_client.post(TWEET_CREATE_API,{
+            'content':'a selfie',
+            'files': [],
+        })
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(TweetPhoto.objects.count(), 0)
+
+        # upload single file
+        # str.encode to convert content to bytes
+        file = SimpleUploadedFile(
+            name='selfie.jpg',
+            content=str.encode('selfie 1'),
+            content_type='image/jpeg'
+        )
+        response = self.user1_client.post(TWEET_CREATE_API,{
+            'content': 'a selfie',
+            'files': [file],
+        })
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(TweetPhoto.objects.count(), 1)
+        # 测试多个文件上传
+        file1 = SimpleUploadedFile(
+            name='selfie1.jpg',
+            content=str.encode('selfie 1'),
+            content_type='image/jpeg',
+        )
+        file2 = SimpleUploadedFile(
+            name='selfie2.jpg',
+            content=str.encode('selfie 2'),
+            content_type='image/jpeg',
+        )
+        response = self.user1_client.post(TWEET_CREATE_API, {
+            'content': 'two selfies',
+            'files': [file1, file2],
+        })
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(TweetPhoto.objects.count(), 3)
+
+        # 从读取的 API 里确保已经包含了 photo 的地址
+        retrieve_url = TWEET_RETRIEVE_API.format(response.data['id'])
+        response = self.user1_client.get(retrieve_url)
+        self.assertEqual(len(response.data['photo_urls']), 2)
+        self.assertEqual('selfie1' in response.data['photo_urls'][0], True)
+        self.assertEqual('selfie2' in response.data['photo_urls'][1], True)
+
+        # 测试上传超过 9 个文件会失败
+        files = [
+            SimpleUploadedFile(
+                name=f'selfie{i}.jpg',
+                content=str.encode(f'selfie{i}'),
+                content_type='image/jpeg',
+            )
+            for i in range(10)
+        ]
+        response = self.user1_client.post(TWEET_CREATE_API, {
+            'content': 'failed due to number of photos exceeded limit',
+            'files': files,
+        })
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(TweetPhoto.objects.count(), 3)

--- a/tweets/constants.py
+++ b/tweets/constants.py
@@ -9,3 +9,5 @@ TWEET_PHOTO_STATUS_CHOICES = (
     (TweetPhotoStatus.APPROVED, 'Approved'),
     (TweetPhotoStatus.REJECTED, 'Rejected'),
 )
+
+TWEET_PHOTOS_UPLOAD_LIMIT = 9

--- a/tweets/services.py
+++ b/tweets/services.py
@@ -1,0 +1,17 @@
+from tweets.models import TweetPhoto
+
+
+class TweetService:
+
+    @classmethod
+    def create_photos_from_files(cls, tweet, files):
+        photos = []
+        for index, file in enumerate(files):
+            photo = TweetPhoto(
+                tweet=tweet,
+                user=tweet.user,
+                file=file,
+                order=index,
+            )
+            photos.append(photo)
+        TweetPhoto.objects.bulk_create(photos)


### PR DESCRIPTION
- Update Tweet Create serializer to support image upload
- Update constant file to limit max number of images uploaded to 9
- Update photo url to Tweet serializer and serializer for details
- Update Unit tests